### PR TITLE
Fix const-ness errors in recent ffmpeg

### DIFF
--- a/src/audioplayerprivate.cpp
+++ b/src/audioplayerprivate.cpp
@@ -150,7 +150,7 @@ bool AudioPlayerPrivate::openAudio( const QString& filename )
 	for ( unsigned i = 0; i < pFormatCtx->nb_streams; i++ )
 	{
         AVStream *stream = pFormatCtx->streams[i];
-        AVCodec *dec = avcodec_find_decoder( stream->codecpar->codec_id );
+        const AVCodec *dec = avcodec_find_decoder( stream->codecpar->codec_id );
 
         if ( !dec )
             continue;

--- a/src/audioplayerprivate.h
+++ b/src/audioplayerprivate.h
@@ -76,7 +76,7 @@ class AudioPlayerPrivate : public QIODevice
 		AVFormatContext *pFormatCtx;
 		int				 audioStream;
 		AVCodecContext  *aCodecCtx;
-		const AVCodec         *pCodec;
+		const AVCodec   *pCodec;
 
         // Software audio resampler
         SwrContext      *pAudioResampler;

--- a/src/audioplayerprivate.h
+++ b/src/audioplayerprivate.h
@@ -76,7 +76,7 @@ class AudioPlayerPrivate : public QIODevice
 		AVFormatContext *pFormatCtx;
 		int				 audioStream;
 		AVCodecContext  *aCodecCtx;
-		AVCodec         *pCodec;
+		const AVCodec         *pCodec;
 
         // Software audio resampler
         SwrContext      *pAudioResampler;

--- a/src/ffmpegvideodecoder.cpp
+++ b/src/ffmpegvideodecoder.cpp
@@ -32,7 +32,7 @@ class FFMpegVideoDecoderPriv
 		AVFormatContext *pFormatCtx;
 		int				 videoStream;
 		AVCodecContext  *pCodecCtx;
-		AVCodec         *pCodec;
+		const AVCodec   *pCodec;
 		AVFrame         *pFrame;
 		AVFrame         *pFrameRGB;
 		SwsContext      *img_convert_ctx;
@@ -104,7 +104,7 @@ bool FFMpegVideoDecoder::openFile( const QString& filename, unsigned int seekto 
 	for ( unsigned i = 0; i < d->pFormatCtx->nb_streams; i++ )
 	{
         AVStream *stream = d->pFormatCtx->streams[i];
-        AVCodec *dec = avcodec_find_decoder( stream->codecpar->codec_id );
+        const AVCodec *dec = avcodec_find_decoder( stream->codecpar->codec_id );
 
         if ( !dec )
             continue;

--- a/src/ffmpegvideoencoder.cpp
+++ b/src/ffmpegvideoencoder.cpp
@@ -64,13 +64,13 @@ class FFMpegVideoEncoderPriv
 
 		// FFmpeg stuff
 		AVFormatContext		*	outputFormatCtx;
-		AVOutputFormat		*	outputFormat;
+		const AVOutputFormat*	outputFormat;
 		AVCodecContext		*	videoCodecCtx;
 		AVCodecContext		*	audioCodecCtx;
 		AVStream			*	videoStream;
 		AVStream			*	audioStream;
-		AVCodec				*	videoCodec;
-		AVCodec				*	audioCodec;
+		const AVCodec		*	videoCodec;
+		const AVCodec		*	audioCodec;
 
 		// Video frame data
 		AVFrame				*	videoFrame;


### PR DESCRIPTION
With these updates I'm able to compile against ffmpeg 6.1. I do still see a lot of warnings and audio does not seem to work correctly in video export, but other functionality seems to be ok.